### PR TITLE
add link to firefox extension store

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Chrome extension to inject a CSS codeblock from Github profiles into the entir
 
 <a href="https://github.com/tiramisyuz/ghcss-ext/releases">Releases (compiled CRXs)</a>
 
-If you use Firefox either use the Firefox branch or get it from the extension store. The extension on the store is maintained by [@zoey-on-github](https://github.com/zoey-on-github).
+If you use Firefox either use the Firefox branch or get it from [the extension store](https://addons.mozilla.org/en-US/firefox/addon/ghcss/). The extension on the store is maintained by [@zoey-on-github](https://github.com/zoey-on-github).
 
 ## Usage
 Put the following into your profile's README.md (**this is just an example**):


### PR DESCRIPTION
the words "the extension store" in README.MD now link to the relevant link at Mozilla Add-ons